### PR TITLE
feat(p0): contact email canonicalisation + Org JSON-LD contactPoint

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -53,7 +53,7 @@ export default function ContactPage() {
           <p style={{ fontSize: 15, color: 'var(--text-muted)', marginBottom: 32 }}>Whether you have a question about a specific book, want to discuss a research collaboration, or need to place a bulk order, Charles is happy to hear from you.</p>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
             {[
-              { icon: '✉', title: 'Email', main: 'charlese1mackay@hotmail.com', sub: 'Usually responds within 24 to 48 hours' },
+              { icon: '✉', title: 'Email', main: 'info@charlesmackaybooks.com', sub: 'Charles wraps and posts orders from Glasgow. Replies usually within 24 to 48 hours.' },
               { icon: '⚑', title: 'Location', main: 'Glasgow, Scotland', sub: 'Ships worldwide from Glasgow' },
               { icon: '🛒', title: 'Online Shop', main: 'charlesmackaybooks.com/books', sub: 'Browse all 20 titles, Royal Mail tracked worldwide' },
             ].map(m => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -69,6 +69,13 @@ const orgJsonLd = {
   description: 'Aviation history books by Charles E. MacKay (aviation historian). 20 titles covering Scottish aviation, WWI and WWII aircraft, and military history.',
   founder: { '@type': 'Person', name: 'Charles E. MacKay', url: 'https://charlesmackaybooks.com/about' },
   address: { '@type': 'PostalAddress', addressLocality: 'Glasgow', addressCountry: 'GB' },
+  contactPoint: {
+    '@type': 'ContactPoint',
+    email: 'info@charlesmackaybooks.com',
+    contactType: 'customer service',
+    areaServed: 'Worldwide',
+    availableLanguage: 'English',
+  },
   sameAs: [
     'https://www.wikidata.org/wiki/Q96824767',
     'https://find-and-update.company-information.service.gov.uk/company/SC858624',

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -65,7 +65,7 @@ export default function PrivacyPage() {
         <li>Postal address available on request via <a href="mailto:info@charlesmackaybooks.com">info@charlesmackaybooks.com</a>.</li>
         <li>
           Contact:{' '}
-          <a href="mailto:charlese1mackay@hotmail.com">charlese1mackay@hotmail.com</a>
+          <a href="mailto:info@charlesmackaybooks.com">info@charlesmackaybooks.com</a>
         </li>
       </ul>
       <p style={p}>
@@ -188,7 +188,7 @@ export default function PrivacyPage() {
       </ul>
       <p style={p}>
         To exercise any of these rights, email us at{' '}
-        <a href="mailto:charlese1mackay@hotmail.com">charlese1mackay@hotmail.com</a>. We will respond within one month.
+        <a href="mailto:info@charlesmackaybooks.com">info@charlesmackaybooks.com</a>. We will respond within one month.
       </p>
 
       <h2 style={h2}>9. Cookies</h2>

--- a/src/app/returns/page.tsx
+++ b/src/app/returns/page.tsx
@@ -66,7 +66,7 @@ export default function ReturnsPage() {
           <h2 style={{ fontFamily: 'var(--font-serif)', fontSize: 22, color: 'var(--text-dark)', marginBottom: 16 }}>How to Return</h2>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
             {[
-              { step: '1', title: 'Contact us', desc: 'Email charlese1mackay@hotmail.com with your order number and reason for return.' },
+              { step: '1', title: 'Contact us', desc: 'Email info@charlesmackaybooks.com with your order number and reason for return.' },
               { step: '2', title: 'Post the book back', desc: 'Send the book to the return address provided. We recommend using a tracked service. Return postage is at the buyer\'s expense unless the item arrived damaged.' },
               { step: '3', title: 'Receive your refund', desc: 'Once we receive the book, your refund will be processed within 5 working days to your original payment method.' },
             ].map(s => (

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -68,7 +68,7 @@ export default function TermsPage() {
         <a href="mailto:info@charlesmackaybooks.com">info@charlesmackaybooks.com</a>.
       </p>
       <p style={p}>
-        Contact: <a href="mailto:charlese1mackay@hotmail.com">charlese1mackay@hotmail.com</a>.
+        Contact: <a href="mailto:info@charlesmackaybooks.com">info@charlesmackaybooks.com</a>.
       </p>
 
       <h2 style={h2}>2. Acceptance of these Terms</h2>
@@ -114,7 +114,7 @@ export default function TermsPage() {
         Under the Consumer Contracts (Information, Cancellation and Additional Charges) Regulations 2013 you have the
         right to cancel a distance-sale contract within 14 days of receiving the goods, without giving any reason. To
         exercise the right, send us a clear written statement (by email to{' '}
-        <a href="mailto:charlese1mackay@hotmail.com">charlese1mackay@hotmail.com</a>) before the 14-day period expires.
+        <a href="mailto:info@charlesmackaybooks.com">info@charlesmackaybooks.com</a>) before the 14-day period expires.
         You must return the goods to us within 14 days of telling us you wish to cancel; the cost of return is yours
         unless the goods are faulty or mis-described. We will refund the price you paid, including the cheapest standard
         delivery cost we offer, within 14 days of receiving the goods back (or evidence that you have sent them).
@@ -126,7 +126,7 @@ export default function TermsPage() {
         <strong>Model Cancellation Form</strong>
         <br />
         To: A Mackay (Publisher) Ltd. Email:{' '}
-        charlese1mackay@hotmail.com (postal address available on request via info@charlesmackaybooks.com)
+        info@charlesmackaybooks.com (postal address available on request via info@charlesmackaybooks.com)
         <br />
         I/We [*] hereby give notice that I/We [*] cancel my/our [*] contract of sale of the following goods [*]/for the
         supply of the following service [*],
@@ -155,7 +155,7 @@ export default function TermsPage() {
         <li>a price reduction or final right to reject if a replacement still does not conform.</li>
       </ul>
       <p style={p}>
-        Email <a href="mailto:charlese1mackay@hotmail.com">charlese1mackay@hotmail.com</a> within 14 days of delivery
+        Email <a href="mailto:info@charlesmackaybooks.com">info@charlesmackaybooks.com</a> within 14 days of delivery
         with your order number and a photograph of the damage. We will reply with the return address; once the book is
         back with us, you may choose a replacement copy or a full refund. Return postage on faulty or mis-described
         goods is at our expense.
@@ -202,7 +202,7 @@ export default function TermsPage() {
       <h2 style={h2}>13. Complaints and dispute resolution</h2>
       <p style={p}>
         We aim to resolve any complaint quickly. Please email{' '}
-        <a href="mailto:charlese1mackay@hotmail.com">charlese1mackay@hotmail.com</a>. If we cannot resolve a dispute, you
+        <a href="mailto:info@charlesmackaybooks.com">info@charlesmackaybooks.com</a>. If we cannot resolve a dispute, you
         may contact Citizens Advice (<a href="https://www.citizensadvice.org.uk/" target="_blank" rel="noopener noreferrer">citizensadvice.org.uk</a>, 0800 144 8848) or Trading Standards via your local council. UK ICO complaints path remains at{' '}
         <a href="https://ico.org.uk/make-a-complaint" target="_blank" rel="noopener noreferrer">ico.org.uk/make-a-complaint</a>.
       </p>


### PR DESCRIPTION
P0 sales-blitz 2026-04-29.

## Audit findings
Most original deliverables were already shipped in HEAD (50832092):
- 410 ghost-routes middleware: shipped in src/middleware.ts
- Security headers (HSTS, X-Frame-Options DENY, Permissions-Policy, X-CTO nosniff, Referrer-Policy, CSP-Report-Only): shipped in next.config.js headers()
- /api/checkout-session: VALID_BOOK_IDS gate, items 1-50, sanitised 400 (Bad request), origin allowlist with Netlify preview regex
- /contact + /api/contact wired to Resend (orders@cmb FROM, reply-to submitter, info@cmb TO) with honeypot and rate-limit
- src/app/sitemap.ts already programmatic (9 static + 20 books + categories)

## Genuine gaps fixed in this PR
1. **Org JSON-LD**: Added contactPoint with email info@charlesmackaybooks.com on / (field was missing entirely)
2. **Email canonicalisation**: replaced 9 instances of charlese1mackay@hotmail.com with info@charlesmackaybooks.com across /contact, /returns, /terms, /privacy. Per #899/#902.

## Phantom URL audit (#925)
Grep of src/ + public/ found ZERO links to /cart, /scottish-aviation-history, /research, /order, /charles-mackay, /category/aviation. /research and /category/aviation already 308 in next.config.js redirects(). Phantom URLs in #925 are external backlinks, not internal links.

Local `npm run build` passes (48 pages prerendered).